### PR TITLE
SB-51300:SAMPLES: Prometheus monitoring system can not get metrics fr…

### DIFF
--- a/web/prometheus-metrics/prometheus-metrics-app/pom.xml
+++ b/web/prometheus-metrics/prometheus-metrics-app/pom.xml
@@ -278,8 +278,8 @@
                                 <waitfor maxwait="10" maxwaitunit="minute" checkevery="500"
                                          timeoutproperty="atimeout">
                                     <resourcecontains
-                                            resource="${project.build.directory}/test-nodes/A.${project.artifactId}/logs/default-engine-for-com.tibco.ep.samples.web.prometheus-metrics-ef.log"
-                                            substring=" sbd at "/>
+                                            resource="${project.build.directory}/test-nodes/A.${project.artifactId}/logs/bootstrap/default-engine-for-com.tibco.ep.samples.web.prometheus-metrics-ef.log"
+                                            substring="Waiting for termination signal "/>
                                 </waitfor>
                                 <fail message="Application on node A failed to startup in time">
                                     <condition>


### PR DESCRIPTION
SB-51300:SAMPLES: Prometheus monitoring system can not get metrics from PrometheusExporterServlet deployed in container