### PR TITLE
SB-54862: add licensing config to sample applications

### DIFF
--- a/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
@@ -22,6 +22,8 @@ String containerLabel = "(c.docker-compatible-linux-3.10 -> c.ansible-2.8-compat
 // See SB-53765 for context.
 def windowsNARLabel = "c.ms-toolset-v142"
 
+def activationServers = params.activationServerUris ?: jobUtil.getDefaultActivationServerUrls()
+
 String executorLabel = jobUtil.getStrBuildLabelEx(
     platform: platform, params: params,
     base: [ all: "c.unix-tools && a.x86_64",
@@ -47,7 +49,7 @@ pipeline {
         choice(name: 'deployArtifacts', choices: ['never', 'default', 'always'], // never first; just for testing
                description: 'The default is never to deploy because this is a test-only pipeline.')
 
-        string(name: 'mavenExtras', defaultValue: "-Dactivation.service.urls=\"https://na1prdstrep01.tibco.com:7070\"",
+        string(name: 'mavenExtras', defaultValue: '',
                description: 'Extra JVM options for Maven, usually -DskipTests and the like.')
 
         booleanParam(name: 'cleanWorkspace', defaultValue: true, description: 'Clean workspace before build.')
@@ -132,7 +134,8 @@ pipeline {
                         useCachedMavenRepository: true,
                         skipJenkinsArtifactPublisher: [ any: true ],
                         archiveArtifacts: [ failure: // entrails
-                                           [ artifacts: epDeclarative.getEPArchiveArtifactsForFailure() ] ]
+                                           [ artifacts: epDeclarative.getEPArchiveArtifactsForFailure() ] ],
+                        mavenExtras: "-Dactivation.service.urls=\"${activationServers}\""
                     )
 
                     // Same as project version.

--- a/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
@@ -24,7 +24,7 @@ def windowsNARLabel = "c.ms-toolset-v142"
 
 def activationServers = params.activationServerUris ?: jobUtil.getDefaultActivationServiceUrls()
 
-def quotedActivationServers = activationServers.split(",").collect{'"' + it + '"'}.join(",")
+def quotedActivationServers = activationServers.split(",").collect{'\\"' + it + '\\"'}.join(",")
 
 String executorLabel = jobUtil.getStrBuildLabelEx(
     platform: platform, params: params,

--- a/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
@@ -24,6 +24,8 @@ def windowsNARLabel = "c.ms-toolset-v142"
 
 def activationServers = params.activationServerUris ?: jobUtil.getDefaultActivationServiceUrls()
 
+def quotedActivationServers = activationServers.split(",").collect{'"' + it + '"'}.join(",")
+
 String executorLabel = jobUtil.getStrBuildLabelEx(
     platform: platform, params: params,
     base: [ all: "c.unix-tools && a.x86_64",
@@ -135,7 +137,7 @@ pipeline {
                         skipJenkinsArtifactPublisher: [ any: true ],
                         archiveArtifacts: [ failure: // entrails
                                            [ artifacts: epDeclarative.getEPArchiveArtifactsForFailure() ] ],
-                        mavenExtras: "-Dactivation.service.urls=\"${activationServers}\""
+                        mavenExtras: "-Dactivation.service.urls=${quotedActivationServers}"
                     )
 
                     // Same as project version.

--- a/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
         choice(name: 'deployArtifacts', choices: ['never', 'default', 'always'], // never first; just for testing
                description: 'The default is never to deploy because this is a test-only pipeline.')
 
-        string(name: 'mavenExtras', defaultValue: '-Dactivation.service.urls="https://na1prdstrep01.tibco.com:7070"',
+        string(name: 'mavenExtras', defaultValue: '-Dactivation.service.urls=\"https://na1prdstrep01.tibco.com:7070\"',
                description: 'Extra JVM options for Maven, usually -DskipTests and the like.')
 
         booleanParam(name: 'cleanWorkspace', defaultValue: true, description: 'Clean workspace before build.')

--- a/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
         choice(name: 'deployArtifacts', choices: ['never', 'default', 'always'], // never first; just for testing
                description: 'The default is never to deploy because this is a test-only pipeline.')
 
-        string(name: 'mavenExtras', defaultValue: '',
+        string(name: 'mavenExtras', defaultValue: '-Dactivation.service.urls="https://na1prdstrep01.tibco.com:7070"',
                description: 'Extra JVM options for Maven, usually -DskipTests and the like.')
 
         booleanParam(name: 'cleanWorkspace', defaultValue: true, description: 'Clean workspace before build.')

--- a/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
@@ -22,7 +22,7 @@ String containerLabel = "(c.docker-compatible-linux-3.10 -> c.ansible-2.8-compat
 // See SB-53765 for context.
 def windowsNARLabel = "c.ms-toolset-v142"
 
-def activationServers = params.activationServerUris ?: jobUtil.getDefaultActivationServerUrls()
+def activationServers = params.activationServerUris ?: jobUtil.getDefaultActivationServiceUrls()
 
 String executorLabel = jobUtil.getStrBuildLabelEx(
     platform: platform, params: params,

--- a/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/samples.test/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
         choice(name: 'deployArtifacts', choices: ['never', 'default', 'always'], // never first; just for testing
                description: 'The default is never to deploy because this is a test-only pipeline.')
 
-        string(name: 'mavenExtras', defaultValue: '-Dactivation.service.urls=\"https://na1prdstrep01.tibco.com:7070\"',
+        string(name: 'mavenExtras', defaultValue: "-Dactivation.service.urls=\"https://na1prdstrep01.tibco.com:7070\"",
                description: 'Extra JVM options for Maven, usually -DskipTests and the like.')
 
         booleanParam(name: 'cleanWorkspace', defaultValue: true, description: 'Clean workspace before build.')

--- a/docker/ef-2node-ansible/ef-2node-ansible-app/pom.xml
+++ b/docker/ef-2node-ansible/ef-2node-ansible-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -58,6 +58,12 @@
         <skipStreamBaseDockerBase>false</skipStreamBaseDockerBase>
         <skipDockerTests>false</skipDockerTests>
         <skipTests>false</skipTests>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
   
     <profiles>

--- a/docker/ef-2node-ansible/ef-2node-ansible-app/src/main/configurations/license.conf
+++ b/docker/ef-2node-ansible/ef-2node-ansible-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/docker/ef-2node-ansible/ef-2node-ansible-app/src/site/markdown/index.md
+++ b/docker/ef-2node-ansible/ef-2node-ansible-app/src/site/markdown/index.md
@@ -25,6 +25,38 @@ Ansible cannot run on a Windows host natively. Please see more information under
 
 All Ansible playbooks are executed based on configuration file and inventory file. Both files are included in the project. Please see more detailed description in [Ansible part of this project paragraph](#ansible-part-of-this-project) below. 
 
+### License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
+
 ## Loading this sample in TIBCO StreamBase&reg; Studio
 
 To be able to run this sample in TIBCO StreamBase&reg; Studio please refer to [Using TIBCO Streambase Studio GitHub page](https://github.com/TIBCOSoftware/tibco-streaming-samples/blob/master/docs/studio.md).
@@ -479,7 +511,7 @@ PLAY RECAP *********************************************************************
 This playbook has two main tasks: stop and remove both containers. Also it will remove the example.com network.
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docker/ef-2node/ef-2node-app/pom.xml
+++ b/docker/ef-2node/ef-2node-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -56,6 +56,12 @@
         <skipApplicationDocker>true</skipApplicationDocker>
         <skipStreamBaseDockerBase>true</skipStreamBaseDockerBase>
         <skipDockerTests>true</skipDockerTests>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
     
     <dependencies>

--- a/docker/ef-2node/ef-2node-app/src/main/configurations/license.conf
+++ b/docker/ef-2node/ef-2node-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/docker/ef-2node/ef-2node-app/src/site/markdown/index.md
+++ b/docker/ef-2node/ef-2node-app/src/site/markdown/index.md
@@ -24,6 +24,38 @@ CPUs and Memory settings on the Advanced tab of Docker preferences.
 
 ![resources](images/resources.png)
 
+### License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
+
 ## Creating an application archive project for Docker from TIBCO StreamBase&reg; Studio
 
 TIBCO StreamBase&reg; Studio can generate a project containing the necessary files to build and 
@@ -313,7 +345,7 @@ maven plugin issues some rather odd warnings :
 These can be ignored.
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docker/ef-helm/ef-helm-app/pom.xml
+++ b/docker/ef-helm/ef-helm-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -57,6 +57,12 @@
         <skipStreamBaseDockerBase>true</skipStreamBaseDockerBase>
         <skipDockerTests>true</skipDockerTests>
         <skipDockerBuild>true</skipDockerBuild>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
     
     <dependencies>

--- a/docker/ef-helm/ef-helm-app/src/main/configurations/license.conf
+++ b/docker/ef-helm/ef-helm-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/docker/ef-helm/ef-helm-app/src/site/markdown/index.md
+++ b/docker/ef-helm/ef-helm-app/src/site/markdown/index.md
@@ -15,6 +15,37 @@ Helm 3 is also required to be installed and configured - see https://helm.sh/doc
 Note that the helm binary must be locatable via PATH - both from the command line and inside
 studio.  This may require setting PATH in studio ( see the Environment tab of the run configurations ).
 
+### License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Quick runthrough
 
@@ -211,3 +242,30 @@ To learn more about the release, try:
 Note that in the above example the Helm variable dockerRegistry is set to the location of the
 docker images.
 
+---
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docker/ef-kubernetes/ef-kubernetes-app/pom.xml
+++ b/docker/ef-kubernetes/ef-kubernetes-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -57,6 +57,12 @@
         <skipStreamBaseDockerBase>true</skipStreamBaseDockerBase>
         <skipDockerTests>true</skipDockerTests>
         <skipDockerBuild>true</skipDockerBuild>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
     
     <dependencies>

--- a/docker/ef-kubernetes/ef-kubernetes-app/src/main/configurations/license.conf
+++ b/docker/ef-kubernetes/ef-kubernetes-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/docker/ef-kubernetes/ef-kubernetes-app/src/site/markdown/index.md
+++ b/docker/ef-kubernetes/ef-kubernetes-app/src/site/markdown/index.md
@@ -8,7 +8,7 @@ node.
 * [Overview](#overview)
 * [Quick runthrough](#quick-runthrough)
 * [Prerequisites](#prerequisites)
-* [Clound native development lifecycle](#cloud-native-development-lifecycle)
+* [Cloud native development lifecycle](#cloud-native-development-lifecycle)
 * [Creating an application archive project for Kubernetes from TIBCO StreamBase® Studio](#creating-an-application-archive-project-for-kubernetes-from-tibco-streambase-studio)
 * [Kubernetes permissions](#kubernetes-permissions)
 * [Cluster monitor](#cluster-monitor)
@@ -100,8 +100,37 @@ statefulset.apps "ef-kubernetes-app" deleted
 
 ## Prerequisites
 
-### Licensing
-A valid TIBCO Activation Service configuration is required before running any StreamBase EventFlow™ applications. The easiest way to do this for local development or testing is to create a license configuration file in the node user's home directory. The process for configuring the license activation is described in the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the TIBCO Streaming documentation.
+### License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ### Kubernetes
 In addition to Docker (see [main Docker sample](../../../../../ef-2node/ef-2node-app/src/site/markdown/index.md) ), 
@@ -1306,3 +1335,31 @@ roleRef:
   name: service-update
 !
 ```
+
+---
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docker/lv-1node/lv-1node-app/pom.xml
+++ b/docker/lv-1node/lv-1node-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -56,6 +56,12 @@
         <skipApplicationDocker>true</skipApplicationDocker>
         <skipStreamBaseDockerBase>true</skipStreamBaseDockerBase>
         <skipDockerTests>true</skipDockerTests>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
     
     <dependencies>

--- a/docker/lv-1node/lv-1node-app/src/main/configurations/license.conf
+++ b/docker/lv-1node/lv-1node-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/docker/lv-1node/lv-1node-app/src/site/markdown/index.md
+++ b/docker/lv-1node/lv-1node-app/src/site/markdown/index.md
@@ -38,6 +38,38 @@ Such a project includes :
 
 Note that whilst this project will create a simple Docker image, changes to the project may be required for additional behaviours. 
 
+### License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
+
 ## Containers and nodes
 
 In this sample we name the docker container as **A.lv-1node-app**,  which hosts the StreamBase node **A.lv-1node-app**, the TIBCO LiveView&trade; Web port 
@@ -180,7 +212,7 @@ $ docker rm A.lv-1node-app
 ```
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docker/pd-test/pd-test-app/pom.xml
+++ b/docker/pd-test/pd-test-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -56,6 +56,12 @@
         <skipApplicationDocker>true</skipApplicationDocker>
         <skipStreamBaseDockerBase>true</skipStreamBaseDockerBase>
         <skipDockerTests>true</skipDockerTests>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
 
     <dependencies>

--- a/docker/pd-test/pd-test-app/src/main/configurations/license.conf
+++ b/docker/pd-test/pd-test-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/docker/pd-test/pd-test-app/src/site/markdown/index.md
+++ b/docker/pd-test/pd-test-app/src/site/markdown/index.md
@@ -10,6 +10,38 @@ do not block the discovery messages.  This sample describes how to use docker to
 
 See also [Docker section in TIBCO® Streaming documentation](https://docs.tibco.com/pub/str/10.4.0/doc/html/admin/part-docker.html).
 
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
+
 ## Creating an application archive project for Docker from TIBCO StreamBase&reg; Studio
 
 TIBCO StreamBase&reg; Studio can generate a project containing the necessary files to build and 
@@ -153,7 +185,7 @@ Use the [maven](https://maven.apache.org) as **mvn install** to build from the c
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/highavailability/aa-2node/aa-2node-app/pom.xml
+++ b/highavailability/aa-2node/aa-2node-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,12 @@
 
     <properties>
         <dockerDomain>example.com</dockerDomain>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
 
     <dependencies>

--- a/highavailability/aa-2node/aa-2node-app/src/main/configurations/license.conf
+++ b/highavailability/aa-2node/aa-2node-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/highavailability/aa-2node/aa-2node-app/src/site/markdown/index.md
+++ b/highavailability/aa-2node/aa-2node-app/src/site/markdown/index.md
@@ -2,12 +2,45 @@
 
 This sample describes how to deploy an EventFlow fragment in a 2-node active active configuration.
 
+* [License Activation Configuration](#license-activation-configuration)
 * [Machines and nodes](#machines-and-nodes)
 * [Data partitioning](#data-partitioning)
 * [Define the node deployment configuration](#define-the-node-deployment-configuration)
 * [Design notes](#design-notes)
 * [Failure scenarios](#failure-scenarios)
 * [Building this sample from the command line and running the integration test cases](#building-this-sample-from-the-command-line-and-running-the-integration-test-cases)
+
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Machines and nodes
 
@@ -72,7 +105,7 @@ Use the [maven](https://maven.apache.org) as **mvn install** to build from the c
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/highavailability/aa-3node-dr/aa-3node-dr-app/pom.xml
+++ b/highavailability/aa-3node-dr/aa-3node-dr-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,12 @@
 
     <properties>
         <dockerDomain>example.com</dockerDomain>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
 
     <dependencies>

--- a/highavailability/aa-3node-dr/aa-3node-dr-app/src/main/configurations/license.conf
+++ b/highavailability/aa-3node-dr/aa-3node-dr-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/highavailability/aa-3node-dr/aa-3node-dr-app/src/site/markdown/index.md
+++ b/highavailability/aa-3node-dr/aa-3node-dr-app/src/site/markdown/index.md
@@ -2,6 +2,7 @@
 
 This sample describes how to deploy an EventFlow fragment in a 3-node active active configuration with disaster recovery
 
+* [License Activation Configuration](#license-activation-configuration)
 * [Machines and nodes](#machines-and-nodes)
 * [Data partitioning](#data-partitioning)
 * [Define the application definition configuration](#define-the-application-definition-configuration)
@@ -9,6 +10,38 @@ This sample describes how to deploy an EventFlow fragment in a 3-node active act
 * [Design notes](#design-notes)
 * [Failure scenarios](#failure-scenarios)
 * [Building this sample from the command line and running the integration test cases](#building-this-sample-from-the-command-line-and-running-the-integration-test-cases)
+
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Machines and nodes
 
@@ -198,7 +231,7 @@ Use the [maven](https://maven.apache.org) as **mvn install** to build from the c
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/highavailability/aa-3node/aa-3node-app/pom.xml
+++ b/highavailability/aa-3node/aa-3node-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,12 @@
 
     <properties>
         <dockerDomain>example.com</dockerDomain>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
 
     <dependencies>

--- a/highavailability/aa-3node/aa-3node-app/src/main/configurations/license.conf
+++ b/highavailability/aa-3node/aa-3node-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/highavailability/aa-3node/aa-3node-app/src/site/markdown/index.md
+++ b/highavailability/aa-3node/aa-3node-app/src/site/markdown/index.md
@@ -2,12 +2,45 @@
 
 This sample describes how to deploy an EventFlow fragment in a 3-node active active configuration.
 
+* [License Activation Configuration](#license-activation-configuration)
 * [Machines and nodes](#machines-and-nodes)
 * [Data partitioning](#data-partitioning)
 * [Define the node deployment configuration](#define-the-node-deployment-configuration)
 * [Design notes](#design-notes)
 * [Failure scenarios](#failure-scenarios)
 * [Building this sample from the command line and running the integration test cases](#building-this-sample-from-the-command-line-and-running-the-integration-test-cases)
+
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Machines and nodes
 
@@ -103,7 +136,7 @@ Use the [maven](https://maven.apache.org) as **mvn install** to build from the c
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/highavailability/as-2node/as-2node-app/pom.xml
+++ b/highavailability/as-2node/as-2node-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,12 @@
 
     <properties>
         <dockerDomain>example.com</dockerDomain>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
 
     <dependencies>

--- a/highavailability/as-2node/as-2node-app/src/main/configurations/license.conf
+++ b/highavailability/as-2node/as-2node-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/highavailability/as-2node/as-2node-app/src/site/markdown/index.md
+++ b/highavailability/as-2node/as-2node-app/src/site/markdown/index.md
@@ -2,6 +2,7 @@
 
 This sample describes how to deploy an EventFlow fragment in a 2-node active standby configuration.
 
+* [License Activation Configuration](#license-activation-configuration)
 * [Machines and nodes](#machines-and-nodes)
 * [Data partitioning](#data-partitioning)
 * [Define the application definition configuration](#define-the-application-definition-configuration)
@@ -9,6 +10,38 @@ This sample describes how to deploy an EventFlow fragment in a 2-node active sta
 * [Design notes](#design-notes)
 * [Failure scenarios](#failure-scenarios)
 * [Building this sample from the command line and running the integration test cases](#building-this-sample-from-the-command-line-and-running-the-integration-test-cases)
+
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Machines and nodes
 
@@ -147,7 +180,7 @@ Use the [maven](https://maven.apache.org) as **mvn install** to build from the c
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/highavailability/ca-polling/ca-polling-app/pom.xml
+++ b/highavailability/ca-polling/ca-polling-app/pom.xml
@@ -2,7 +2,7 @@
 <!--
   vim: set tabstop=4 softtabstop=0 expandtab shiftwidth=4 smarttab :
 
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -49,6 +49,14 @@
         <version>11.2.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
+
+    <properties>
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
+    </properties>
 
     <dependencies>
         <dependency>

--- a/highavailability/ca-polling/ca-polling-app/src/main/configurations/license.conf
+++ b/highavailability/ca-polling/ca-polling-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/highavailability/ca-polling/ca-polling-app/src/site/markdown/index.md
+++ b/highavailability/ca-polling/ca-polling-app/src/site/markdown/index.md
@@ -2,11 +2,44 @@
 
 This sample describes how to deploy an EventFlow fragment in a 2-node cluster aware configuration.
 
+* [License Activation Configuration](#license-activation-configuration)
 * [Machines and nodes](#machines-and-nodes)
 * [Define the node deployment configuration](#define-the-node-deployment-configuration)
 * [Design notes](#design-notes)
 * [Failure scenarios](#failure-scenarios)
 * [Building this sample from the command line and running the integration test cases](#building-this-sample-from-the-command-line-and-running-the-integration-test-cases)
+
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Machines and nodes
 
@@ -55,7 +88,7 @@ Use [maven](https://maven.apache.org) as **mvn install** to build from the comma
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/highavailability/ca-statefilter/ca-statefilter-app/pom.xml
+++ b/highavailability/ca-statefilter/ca-statefilter-app/pom.xml
@@ -2,7 +2,7 @@
 <!--
   vim: set tabstop=4 softtabstop=0 expandtab shiftwidth=4 smarttab :
 
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -49,6 +49,14 @@
         <version>11.2.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
+
+    <properties>
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
+    </properties>
 
     <dependencies>
         <dependency>

--- a/highavailability/ca-statefilter/ca-statefilter-app/src/main/configurations/license.conf
+++ b/highavailability/ca-statefilter/ca-statefilter-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/highavailability/ca-statefilter/ca-statefilter-app/src/site/markdown/index.md
+++ b/highavailability/ca-statefilter/ca-statefilter-app/src/site/markdown/index.md
@@ -2,11 +2,44 @@
 
 This sample describes how to deploy an EventFlow fragment in a 2-node cluster aware configuration.
 
+* [License Activation Configuration](#license-activation-configuration)
 * [Machines and nodes](#machines-and-nodes)
 * [Define the node deployment configuration](#define-the-node-deployment-configuration)
 * [Design notes](#design-notes)
 * [Failure scenarios](#failure-scenarios)
 * [Building this sample from the command line and running the integration test cases](#building-this-sample-from-the-command-line-and-running-the-integration-test-cases)
+
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Machines and nodes
 
@@ -53,7 +86,7 @@ Use [maven](https://maven.apache.org) as **mvn install** to build from the comma
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/highavailability/pd-2node/pd-2node-app/pom.xml
+++ b/highavailability/pd-2node/pd-2node-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,12 @@
 
     <properties>
         <dockerDomain>example.com</dockerDomain>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
 
     <dependencies>

--- a/highavailability/pd-2node/pd-2node-app/src/main/configurations/license.conf
+++ b/highavailability/pd-2node/pd-2node-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/highavailability/pd-2node/pd-2node-app/src/site/markdown/index.md
+++ b/highavailability/pd-2node/pd-2node-app/src/site/markdown/index.md
@@ -2,12 +2,45 @@
 
 This sample describes how to deploy an EventFlow fragment in a 2-node active active configuration with proxy discovery.
 
+* [License Activation Configuration](#license-activation-configuration)
 * [Machines and nodes](#machines-and-nodes)
 * [Data partitioning](#data-partitioning)
 * [Define the node deployment configuration](#define-the-node-deployment-configuration)
 * [Design notes](#design-notes)
 * [Failure scenarios](#failure-scenarios)
 * [Building this sample from the command line and running the integration test cases](#building-this-sample-from-the-command-line-and-running-the-integration-test-cases)
+
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
 
 ## Machines and nodes
 
@@ -127,7 +160,7 @@ Use the [maven](https://maven.apache.org) as **mvn install** to build from the c
 ![maven](images/maven.gif)
 
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/structure/application/application-app/pom.xml
+++ b/structure/application/application-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018-2023 Cloud Software Group, Inc.
+  Copyright (c) 2018-2025 Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -51,6 +51,12 @@
 
     <properties>
         <dockerDomain>example.com</dockerDomain>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
     
     <dependencies>

--- a/structure/application/application-app/src/main/configurations/license.conf
+++ b/structure/application/application-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/structure/application/application-app/src/site/markdown/index.md
+++ b/structure/application/application-app/src/site/markdown/index.md
@@ -23,12 +23,13 @@ This sample's structure is shown below :
 ```
 ├── pom.xml
 ├── one or more fragment modules
-├── application-application
+├── application-app
 │   ├── pom.xml
 │   └── src
 │       ├── main
 │       │   ├── configurations
 │       │   │   └── app.conf
+│       │   │   └── license.conf
 │       │   └── docker
 │       │       ├── application
 │       │       │   └── Dockerfile
@@ -51,8 +52,40 @@ This sample's structure is shown below :
 │           └── resources
 ```
 
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
+
 ---
-Copyright (c) 2018-2023 Cloud Software Group, Inc.
+Copyright (c) 2018-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/web/prometheus-metrics/prometheus-metrics-app/pom.xml
+++ b/web/prometheus-metrics/prometheus-metrics-app/pom.xml
@@ -55,8 +55,14 @@
     <properties>
         <dockerDomain>example.com</dockerDomain>
         <skipDockerTests>true</skipDockerTests>
-        <!-- FIX THIS: TOZHU: SB-51300 -->
+        <!-- FIX THIS: SB-51300 -->
         <skipTests>true</skipTests>
+
+        <!-- Define the following property with the quoted URL(s) of the TIBCO Activation Service -->
+        <!-- <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls> -->
+
+        <!-- Uncomment to not require the activation.service.urls property -->
+        <!-- <skip.require.activation.service.urls>true</skip.require.activation.service.urls> -->
     </properties>
 
     <dependencies>

--- a/web/prometheus-metrics/prometheus-metrics-app/src/main/configurations/license.conf
+++ b/web/prometheus-metrics/prometheus-metrics-app/src/main/configurations/license.conf
@@ -1,0 +1,39 @@
+//  Copyright (c) 2025 Cloud Software Group, Inc.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+// Licensing configuration
+//
+name = "license-configuration"
+version = "1.0.0"
+type = "com.tibco.ep.dtm.configuration.licensing"
+
+configuration = {
+    LicenseInfo = {
+        activationServiceURLs = [ ${activation.service.urls} ]
+    }
+}

--- a/web/prometheus-metrics/prometheus-metrics-app/src/site/markdown/index.md
+++ b/web/prometheus-metrics/prometheus-metrics-app/src/site/markdown/index.md
@@ -2,6 +2,38 @@
 
 This sample describes how to retrieve TIBCO&reg; Streaming Metrics into Prometheus.
 
+## License Activation Configuration
+
+A valid TIBCO Activation Service configuration is required before running any StreamBase applications.
+This sample contains a license configuration file in `src/main/configurations/license.conf`, which requires
+a Maven property `activation.service.urls` be defined with the quoted URL(s) of one or more TIBCO Activation
+Service instances. This property may be defined in the properties section of the `pom.xml` file:
+
+    <properties>
+        <!-- single activation server -->
+        <activation.service.urls>"https://example.com:7070"</activation.service.urls>
+
+        <!-- multiple activation servers -->
+        <activation.service.urls>"https://example1.com:7070","https://example2.com:7070"</activation.service.urls>
+    </properties>
+
+It may also be defined on the maven command line:
+
+    mvn install -Dactivation.service.urls=\"https://example.com:7070\"
+    mvn install -Dactivation.service.urls=\"https://example1.com:7070\",\"https://example2.com:7070\"
+
+Note that the quotes must be escaped on the command line.
+
+It is also possible to define a local license file under the user's home directory, containing the Activation
+Service URL(s). However, because a license configuration file in a Streambase application archive takes
+precedence over a local license file, the `src/main/configurations/license.conf` file must be deleted from
+the project in order for the local license file to be used. Note that the use of local license files is
+not recommended for production deployments, because it requires that each machine running Streaming
+Application(s) have a local license configuration for the user account under which the node runs.
+
+Refer to the **Welcome Guide > Activation in TIBCO Streaming and Model Management Server** page in the
+TIBCO Streaming documentation for more details on license activation.
+
 ## Prometheus integration
 
 A node **A** will be started containing the **prometheus-metrics-ef** event flow, itself depending
@@ -46,7 +78,7 @@ If docker cannot be found on the machine, the tests will only consists in a star
 application, without the Prometheus container start/stop and without the java integration test. 
 
 ---
-Copyright (c) 2020-2023 Cloud Software Group, Inc.
+Copyright (c) 2020-2025 Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
* Supporting changes in the application parent pom in ep-streaming-runtime
* Sample applications require a activation.service.urls maven property with activation service URL(s)
* Parent enforces the property is defined so users get a useful error message if the property is not defined
* Property enforcement can be disabled for alternative/custom licensing configuration
* Site docs updated to doc all this

Known issues that need resolved:
* I am not sure of the best place to put the activation server URL. Currently it is in the Jenkinsfile.
* Because the activation.service.urls supports multiple URLs, and they have to be individually quoted and comma separated in the license file, the URL(s) need to be quoted: [-Dprop="foo","bar"]. I've tried a couple ways to make that happen but it is not working. Since the URL may need to be moved out of the Jenkinsfile, I am punting on fixing it there for now.